### PR TITLE
Minor rework of mapping logic

### DIFF
--- a/genre_mapping.py
+++ b/genre_mapping.py
@@ -81,6 +81,55 @@ MULTI_GENRE_MAPPER = {
     "['Adventure', 'Platform']":              Genre.PLATFORM,
     "['Adventure', 'Simulation']":            Genre.ADVENTURE_VISUAL,
     "['Arcade', 'Paddle / Pong']":            Genre.MISC,
+    "['Board / Party Game', 'Role-Playing']": Genre.PUZZLE,
     "['Board / Party Game', 'Role-Playing', 'Strategy']": Genre.PUZZLE,
     "['Platform', 'Shooter']":                Genre.SHMUP, 
 }
+
+# Convert multi genres exo collection format to a single one
+def mapGenres(input_genres):
+    # list unique genres and sort them - precedence is alphabetical unless overridden
+    # (e.g. "Managerial" + "Simulation" -> "Managerial")
+    genres = sorted([g.strip() for g in list(set(input_genres))])
+
+    # first check for  multi-genre overrides
+    if str(genres) in MULTI_GENRE_MAPPER:
+        return MULTI_GENRE_MAPPER.get(str(genres)).value
+    
+    # classifies about ~90 games, the simulation aspect is more prominent
+    if 'Vehicle Simulation' in genres or 'Flight Simulator' in genres:
+        return Genre.SIMULATION.value  
+        
+    # recategorize education games
+    if 'Education' in genres or 'Quiz' in genres:
+        if 'Adventure' in genres or 'Visual Novel' in genres:
+            return Genre.ADVENTURE_VISUAL.value
+        return Genre.MISC.value
+    
+    # debatable, affects only a few games but usually the FPS aspect is more prominent than the rest
+    if 'First Person Shooter' in genres:
+        return Genre.FPS.value
+
+    # RPG takes precedence over adventure and others for ~60 games
+    if 'RPG' in genres or 'Role-Playing' in genres:
+        return Genre.RPG.value
+    
+    # puzzle takes precedence for ~50 games e.g. lrunn2, jetpack, oddworld
+    if 'Puzzle' in genres:
+        return Genre.PUZZLE.value
+    
+    # from here on, ignore 'Action' or 'Arcade' if there are subgenres defined, 
+    # otherwise they always take precedence
+    if len(genres) > 1 and genres[0] == 'Action':
+        genres.pop(0)
+    if len(genres) > 1 and genres[0] == 'Arcade':
+        genres.pop(0)
+    
+    # returns the first genre found, alphabetically
+    for genre in genres:
+        output = GENRE_MAPPER.get(genre, Genre.UNKNOWN)
+        if output != Genre.UNKNOWN:
+            return output.value
+    
+    # fallback - there are probably no genres defined (or Exo added a new genre name)
+    return Genre.UNKNOWN.value

--- a/genre_mapping.py
+++ b/genre_mapping.py
@@ -1,0 +1,86 @@
+from enum import Enum
+
+class Genre(Enum):
+    # the target genres we want to map to
+    UNKNOWN             = "Unknown"
+    MISC                = "Misc"
+    ACTION_ADVENTURE    = "Action-Adventure"
+    ADVENTURE_VISUAL    = "Adventure-Visual"
+    BEATEMUP            = "BeatEmUp"
+    FPS                 = "Gun-FPS"
+    PINBALL             = "Pinball"
+    PLATFORM            = "Platform"
+    PUZZLE              = "Puzzle"
+    RACING              = "Racing"
+    RPG                 = "RPG"
+    SIMULATION          = "Simulation"
+    SHMUP               = "ShootEmUp"
+    SPORTS              = "Sport"
+    STRATEGY_MANAGEMENT = "Strategy-Management"
+    TOOLS               = "Tools"
+
+# defines direct mappings (i.e. if match, return the value)
+GENRE_MAPPER = {
+    'Action':               Genre.ACTION_ADVENTURE,
+    'Adventure':            Genre.ADVENTURE_VISUAL,
+    'App':                  Genre.TOOLS,
+    'Arcade':               Genre.MISC,
+    'Beat \'em Up':         Genre.BEATEMUP,
+    'Board / Party Game':   Genre.PUZZLE,
+    'Board':                Genre.PUZZLE,
+    'Cards / Tiles':        Genre.PUZZLE,
+    'Casino':               Genre.PUZZLE,
+    'Construction and Management Simulation': Genre.STRATEGY_MANAGEMENT,
+    'Creativity':           Genre.TOOLS,
+    'Driving':              Genre.RACING,
+    'FPS':                  Genre.FPS,
+    'Fighting':             Genre.BEATEMUP,
+    'First Person Shooter': Genre.FPS,
+    'Flight Simulator':     Genre.SIMULATION,
+    'Game Show':            Genre.PUZZLE,
+    'Interactive Fiction':  Genre.ADVENTURE_VISUAL,
+    'Interactive Movie':     Genre.ADVENTURE_VISUAL,
+    'Life Simulation':      Genre.MISC,
+    'Managerial':           Genre.STRATEGY_MANAGEMENT,
+    'Pinball':              Genre.PINBALL,
+    'Platform':             Genre.PLATFORM,
+    'Puzzle':               Genre.PUZZLE,
+    'RPG':                  Genre.RPG,
+    'Racing / Driving':     Genre.RACING,
+    'Racing':               Genre.RACING,
+    'Reference':            Genre.TOOLS,    
+    'Role-Playing':         Genre.RPG,
+    'Paddle / Pong':        Genre.ACTION_ADVENTURE,
+    'Shooter':              Genre.SHMUP,
+    'Simulation':           Genre.SIMULATION,
+    'Sports':               Genre.SPORTS,
+    'Strategy':             Genre.STRATEGY_MANAGEMENT,
+    'Text-Based':           Genre.ADVENTURE_VISUAL,
+    'Vehicle Simulation':   Genre.SIMULATION,
+    'Visual Novel':         Genre.ADVENTURE_VISUAL,
+}    
+
+# as above, but applies for combined genres (used for overides)
+MULTI_GENRE_MAPPER = {
+    "['Action', 'Arcade']":                   Genre.ACTION_ADVENTURE,
+    "['Action', 'Adventure']":                Genre.ACTION_ADVENTURE,
+    "['Action', 'Adventure', 'Fighting']":    Genre.BEATEMUP,
+    "['Action', 'Adventure', 'Platform']":    Genre.PLATFORM,
+    "['Action', 'Adventure', 'Text-Based']":  Genre.ACTION_ADVENTURE,
+    "['Action', 'Adventure', 'Simulation']":  Genre.ACTION_ADVENTURE,
+    "['Action', 'Fighting', 'Role-Playing']": Genre.BEATEMUP,
+    "['Action', 'Platform', 'Role-Playing']": Genre.PLATFORM,
+    "['Action', 'Adventure', 'Shooter']":     Genre.SHMUP,
+    "['Action', 'Adventure', 'Platform', 'Puzzle']": Genre.PUZZLE,
+    "['Action', 'Fighting', 'Shooter']":      Genre.SHMUP,
+    "['Action', 'Fighting', 'Platform']":     Genre.PLATFORM,
+    "['Action', 'Platform', 'Shooter']":      Genre.SHMUP,
+    "['Action', 'Role-Playing', 'Shooter']":  Genre.SHMUP,
+    "['Action', 'Adventure', 'Platform', 'Shooter']": Genre.SHMUP,
+    "['Adventure', 'Fighting']":              Genre.BEATEMUP,
+    "['Adventure', 'Platform']":              Genre.PLATFORM,
+    "['Adventure', 'Simulation']":            Genre.ADVENTURE_VISUAL,
+    "['Arcade', 'Paddle / Pong']":            Genre.MISC,
+    "['Board / Party Game', 'Role-Playing', 'Strategy']": Genre.PUZZLE,
+    "['Platform', 'Shooter']":                Genre.SHMUP, 
+}

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -71,8 +71,30 @@ GENRE_MAPPER = {
     'Vehicle Simulation':   Genre.SIMULATION,
     'Visual Novel':         Genre.ADVENTURE_VISUAL,
 }    
-         
-         
+
+# as above, but applies for combined genres (used for overides)
+MULTI_GENRE_MAPPER = {
+    "['Action', 'Arcade']":                   Genre.ACTION_ADVENTURE,
+    "['Action', 'Adventure']":                Genre.ACTION_ADVENTURE,
+    "['Action', 'Adventure', 'Fighting']":    Genre.BEATEMUP,
+    "['Action', 'Adventure', 'Platform']":    Genre.PLATFORM,
+    "['Action', 'Adventure', 'Text-Based']":  Genre.ACTION_ADVENTURE,
+    "['Action', 'Adventure', 'Simulation']":  Genre.ACTION_ADVENTURE,
+    "['Action', 'Fighting', 'Role-Playing']": Genre.BEATEMUP,
+    "['Action', 'Platform', 'Role-Playing']": Genre.PLATFORM,
+    "['Action', 'Adventure', 'Shooter']":     Genre.SHMUP,
+    "['Action', 'Adventure', 'Platform', 'Puzzle']": Genre.PUZZLE,
+    "['Action', 'Fighting', 'Shooter']":      Genre.SHMUP,
+    "['Action', 'Fighting', 'Platform']":     Genre.PLATFORM,
+    "['Action', 'Platform', 'Shooter']":      Genre.SHMUP,
+    "['Action', 'Role-Playing', 'Shooter']":  Genre.SHMUP,
+    "['Action', 'Adventure', 'Platform', 'Shooter']": Genre.SHMUP,
+    "['Adventure', 'Fighting']":              Genre.BEATEMUP,
+    "['Adventure', 'Platform']":              Genre.PLATFORM,
+    "['Adventure', 'Simulation']":            Genre.ADVENTURE_VISUAL,
+    "['Board / Party Game', 'Role-Playing', 'Strategy']": Genre.PUZZLE,
+    "['Platform', 'Shooter']":                Genre.SHMUP, 
+}
 
 # Metadata exporting
 class MetadataHandler:
@@ -204,7 +226,12 @@ class MetadataHandler:
         # list unique genres and sort them - precedence is alphabetical unless overridden
         # (e.g. "Managerial" + "Simulation" -> "Managerial")
         genres = sorted([g.strip() for g in list(set(dosGame.genres))])
+
+        # first check for  multi-genre overrides
+        if str(genres) in MULTI_GENRE_MAPPER:
+            return MULTI_GENRE_MAPPER.get(str(genres)).value
         
+        # classifies about ~90 games, the simulation aspect is more prominent
         if 'Vehicle Simulation' in genres or 'Flight Simulator' in genres:
             return Genre.SIMULATION.value  
             
@@ -213,57 +240,18 @@ class MetadataHandler:
             if 'Adventure' in genres or 'Visual Novel' in genres:
                 return Genre.ADVENTURE_VISUAL.value
             return Genre.MISC.value
-            
+        
+        # debatable, affects only a few games but usually the FPS aspect is more prominent than the rest
         if 'First Person Shooter' in genres:
             return Genre.FPS.value
-            
-        if 'Board / Party Game' in genres:
-            return Genre.PUZZLE.value
-        
-        # RPG takes precedence over adventure
+
+        # RPG takes precedence over adventure and others for ~60 games
         if 'RPG' in genres or 'Role-Playing' in genres:
-            # but give precedence to these other tags
-            if 'Shooter' in genres:
-                return Genre.SHMUP.value
-            if 'Fighting' in genres:
-                return Genre.BEATEMUP.value
-            if 'Platform' in genres:
-                return Genre.PLATFORM.value
             return Genre.RPG.value
-
-        if genres == ['Action']:
-            return Genre.ACTION_ADVENTURE.value
-
-        if genres == ['Action', 'Arcade']:
-            return Genre.ACTION_ADVENTURE.value
-        
-        if genres == ['Action', 'Adventure']:
-            return Genre.ACTION_ADVENTURE.value
-         
-        if genres == ['Action', 'Adventure', 'Text-Based']:
-            return Genre.ACTION_ADVENTURE.value
-        
-        if genres == ['Action', 'Adventure', 'Simulation']:
-            return Genre.ACTION_ADVENTURE.value
-        
-        if genres == ['Adventure', 'Simulation']:
-            return Genre.ADVENTURE_VISUAL.value
         
         # puzzle takes precedence for ~50 games e.g. lrunn2, jetpack, oddworld
         if 'Puzzle' in genres:
             return Genre.PUZZLE.value
-        
-        # debarable - this makes platform/shooters come up as shmup (e.g. turrican, duken12)
-        if 'Shooter' in genres:
-           return Genre.SHMUP.value
-        
-        # platform takes precedence over fighting and adventure
-        if 'Platform' in genres:
-            return Genre.PLATFORM.value
-        
-        # reclassify cotsword, sidewalk, batret, qeye, spidssix
-        if 'Fighting' in genres:
-            return Genre.BEATEMUP.value
         
         # from here on, ignore 'Action' or 'Arcade' if there are subgenres defined, 
         # otherwise they always take precedence

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -12,13 +12,12 @@ DosGame = collections.namedtuple('DosGame',
                                  'dosname metadataname name genres publisher developer year frontPic manual desc')
 
 
-class GameGenres(Enum):
+class Genre(Enum):
     # the target genres we want to map to
     UNKNOWN             = "Unknown"
     MISC                = "Misc"
     ACTION_ADVENTURE    = "Action-Adventure"
     ADVENTURE_VISUAL    = "Adventure-Visual"
-    ADVENTURE_TEXT      = "Adventure-Text"
     BEATEMUP            = "BeatEmUp"
     FPS                 = "Gun-FPS"
     PINBALL             = "Pinball"
@@ -28,46 +27,49 @@ class GameGenres(Enum):
     RPG                 = "RPG"
     SIMULATION          = "Simulation"
     SHMUP               = "ShootEmUp"
-    SPORTS              = "Sports"
+    SPORTS              = "Sport"
     STRATEGY_MANAGEMENT = "Strategy-Management"
     TOOLS               = "Tools"
 
 # defines direct mappings (i.e. if match, return the value)
-GAME_MAPPER = {
-    'Action':               GameGenres.ACTION_ADVENTURE,
-    'Adventure':            GameGenres.ADVENTURE_VISUAL,
-    'App':                  GameGenres.TOOLS,
-    'Arcade':               GameGenres.MISC,
-    'Beat \'em Up':         GameGenres.BEATEMUP,
-    'Board / Party Game':   GameGenres.PUZZLE,
-    'Board':                GameGenres.PUZZLE,
-    'Cards / Tiles':        GameGenres.PUZZLE,
-    'Casino':               GameGenres.PUZZLE,
-    'Construction and Management Simulation': GameGenres.STRATEGY_MANAGEMENT,
-    'Creativity':           GameGenres.TOOLS,
-    'Driving':              GameGenres.RACING,
-    'FPS':                  GameGenres.FPS,
-    'Fighting':             GameGenres.BEATEMUP,
-    'First Person Shooter': GameGenres.FPS,
-    'Flight Simulator':     GameGenres.SIMULATION,
-    'Game Show':            GameGenres.PUZZLE,
-    'Interactive Fiction':  GameGenres.ADVENTURE_TEXT,
-    'Life Simulation':      GameGenres.MISC,
-    'Managerial':           GameGenres.STRATEGY_MANAGEMENT,
-    'Pinball':              GameGenres.PINBALL,
-    'Platform':             GameGenres.PLATFORM,
-    'Puzzle':               GameGenres.PUZZLE,
-    'RPG':                  GameGenres.RPG,
-    'Racing / Driving':     GameGenres.RACING,
-    'Racing':               GameGenres.RACING,
-    'Reference':            GameGenres.TOOLS,    
-    'Role-Playing':         GameGenres.RPG,
-    'Shooter':              GameGenres.SHMUP,
-    'Simulation':           GameGenres.SIMULATION,
-    'Sports':               GameGenres.SPORTS,
-    'Strategy':             GameGenres.STRATEGY_MANAGEMENT,
-    'Vehicle Simulation':   GameGenres.SIMULATION,
-    'Visual Novel':         GameGenres.ADVENTURE_VISUAL,
+GENRE_MAPPER = {
+    'Action':               Genre.ACTION_ADVENTURE,
+    'Adventure':            Genre.ADVENTURE_VISUAL,
+    'App':                  Genre.TOOLS,
+    'Arcade':               Genre.MISC,
+    'Beat \'em Up':         Genre.BEATEMUP,
+    'Board / Party Game':   Genre.PUZZLE,
+    'Board':                Genre.PUZZLE,
+    'Cards / Tiles':        Genre.PUZZLE,
+    'Casino':               Genre.PUZZLE,
+    'Construction and Management Simulation': Genre.STRATEGY_MANAGEMENT,
+    'Creativity':           Genre.TOOLS,
+    'Driving':              Genre.RACING,
+    'FPS':                  Genre.FPS,
+    'Fighting':             Genre.BEATEMUP,
+    'First Person Shooter': Genre.FPS,
+    'Flight Simulator':     Genre.SIMULATION,
+    'Game Show':            Genre.PUZZLE,
+    'Interactive Fiction':  Genre.ADVENTURE_VISUAL,
+    'Interactive Movie':     Genre.ADVENTURE_VISUAL,
+    'Life Simulation':      Genre.MISC,
+    'Managerial':           Genre.STRATEGY_MANAGEMENT,
+    'Pinball':              Genre.PINBALL,
+    'Platform':             Genre.PLATFORM,
+    'Puzzle':               Genre.PUZZLE,
+    'RPG':                  Genre.RPG,
+    'Racing / Driving':     Genre.RACING,
+    'Racing':               Genre.RACING,
+    'Reference':            Genre.TOOLS,    
+    'Role-Playing':         Genre.RPG,
+    'Paddle / Pong':        Genre.ACTION_ADVENTURE,
+    'Shooter':              Genre.SHMUP,
+    'Simulation':           Genre.SIMULATION,
+    'Sports':               Genre.SPORTS,
+    'Strategy':             Genre.STRATEGY_MANAGEMENT,
+    'Text-Based':           Genre.ADVENTURE_VISUAL,
+    'Vehicle Simulation':   Genre.SIMULATION,
+    'Visual Novel':         Genre.ADVENTURE_VISUAL,
 }    
    # unique, sort, get first then apply special
    
@@ -111,6 +113,7 @@ class MetadataHandler:
     def parseXmlMetadata(self):
         xmlPath = os.path.join(self.exoCollectionDir, 'xml', util.getCollectionMetadataID(self.collectionVersion) + '.xml')
         metadatas = dict()
+        print (xmlPath)
         if os.path.exists(xmlPath):
             parser = etree.XMLParser(encoding="utf-8")
             games = etree.parse(xmlPath, parser=parser).findall(".//Game")
@@ -129,7 +132,7 @@ class MetadataHandler:
                         genres = self.get(g, 'Genre').split(';') if self.get(g, 'Genre') is not None else []
                         manual = self.get(g, 'ManualPath')
                         manualpath = util.localOSPath(os.path.join(self.exoCollectionDir, manual)) if manual is not None else None
-                        frontPic = util.findPics(name, self.cache)
+                        frontPic = None #util.findPics(name, self.cache)
                         metadata = DosGame(dosname, metadataname, name, genres, publisher, developer, releasedate, frontPic,
                                            manualpath, desc)
                         metadatas[metadata.dosname.lower()] = metadata
@@ -200,28 +203,81 @@ class MetadataHandler:
     def buildGenre(self, dosGame):
         
         if dosGame is None or dosGame.genres is None:
-            return GameGenres.UNKNOWN.value
+            return Genre.UNKNOWN.value
         
-        # list unique genres and sort them - precedence is alphabetical (e.g. "Managerial" + "Simulation" -> "Managerial")
-        genres = [g.strip() for g in list(set(dosGame.genres))]
-        genres.sort()
+        # list unique genres and sort them - precedence is alphabetical unless overridden
+        # (e.g. "Managerial" + "Simulation" -> "Managerial")
+        genres = sorted([g.strip() for g in list(set(dosGame.genres))])
         
-        # added handling for special cases
-        if 'Aventure' in genres and 'Action' in genres:
-            return GameGenres.ACTION_ADVENTURE.value
-        
+        if 'Vehicle Simulation' in genres or 'Flight Simulator' in genres:
+            return Genre.SIMULATION.value  
+            
+        # recategorize education games
         if 'Education' in genres or 'Quiz' in genres:
             if 'Adventure' in genres or 'Visual Novel' in genres:
-                return GameGenres.ACTION_ADVENTURE.value
-            return GameGenres.MISC.value
+                return Genre.ADVENTURE_VISUAL.value
+            return Genre.MISC.value
+            
+        if 'First Person Shooter' in genres:
+            return Genre.FPS.value
+            
+        if 'Board / Party Game' in genres:
+            return Genre.PUZZLE.value
+            
+        # separate RPGs of any type
+        if 'RPG' in genres or 'Role-Playing' in genres:
+            if 'Shooter' in genres:
+                return Genre.SHMUP.value
+            if 'Fighting' in genres:
+                return Genre.BEATEMUP.value
+            if 'Platform' in genres:
+                return Genre.PLATFORM.value
+            return Genre.RPG.value
         
+        # remove action/adventure if more tags are defined
+        if 'Adventure' in genres and 'Action' in genres:
+            if len(genres) == 2:
+                return Genre.ACTION_ADVENTURE.value
+            else:
+                if genres == ['Action', 'Adventure', 'Text-Based']:
+                    return Genre.ACTION_ADVENTURE.value
+                genres.pop(genres.index('Action'))
+                genres.pop(genres.index('Adventure'))
+        
+        # prevent categorization as 'adventure' as these usually aren't arcade
+        if 'Arcade' in genres and 'Adventure' in genres:
+            return Genre.ACTION_ADVENTURE.value
+        
+        if genres == ['Action', 'Arcade']:
+            return Genre.ACTION_ADVENTURE.value
+        
+        # prioritize these categories over others from here on
+        if 'Puzzle' in genres:
+            return Genre.PUZZLE.value
+
+        if 'Shooter' in genres:
+            return Genre.SHMUP.value
+        
+        if 'Platform' in genres:
+            return Genre.PLATFORM.value
+        
+        if 'Fighting' in genres:
+            return Genre.BEATEMUP.value
+        
+        # from here on, ignore 'Action' if there are subgenres defined
+        if len(genres) > 1 and genres[0] == 'Action':
+            genres.pop(0)
+        
+        # same logic for Arcade
+        if len(genres) > 1 and genres[0] == 'Arcade':
+            genres.pop(0)
+                
         # if not in special cases, return the first mapped genre found
         for genre in genres:
-            output = GAME_MAPPER.get(genre, GameGenres.UNKNOWN)
-            if output != GameGenres.UNKNOWN:
+            output = GENRE_MAPPER.get(genre, Genre.UNKNOWN)
+            if output != Genre.UNKNOWN:
                 return output.value
         
         # fallback - probably no genres defined
-        return GameGenres.UNKNOWN.value
-            
-
+        return Genre.UNKNOWN.value
+        

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -71,9 +71,6 @@ GENRE_MAPPER = {
     'Vehicle Simulation':   Genre.SIMULATION,
     'Visual Novel':         Genre.ADVENTURE_VISUAL,
 }    
-   # unique, sort, get first then apply special
-   
-
          
          
 

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -7,7 +7,7 @@ import sys
 import xml.etree.ElementTree as etree
 from xml.dom import minidom
 
-from genre_mapping import Genre, GENRE_MAPPER, MULTI_GENRE_MAPPER
+from genre_mapping import mapGenres, Genre
 
 DosGame = collections.namedtuple('DosGame',
                                  'dosname metadataname name genres publisher developer year frontPic manual desc')
@@ -139,49 +139,7 @@ class MetadataHandler:
         if dosGame is None or dosGame.genres is None:
             return Genre.UNKNOWN.value
         
-        # list unique genres and sort them - precedence is alphabetical unless overridden
-        # (e.g. "Managerial" + "Simulation" -> "Managerial")
-        genres = sorted([g.strip() for g in list(set(dosGame.genres))])
-
-        # first check for  multi-genre overrides
-        if str(genres) in MULTI_GENRE_MAPPER:
-            return MULTI_GENRE_MAPPER.get(str(genres)).value
+        return mapGenres(dosGame.genres)
         
-        # classifies about ~90 games, the simulation aspect is more prominent
-        if 'Vehicle Simulation' in genres or 'Flight Simulator' in genres:
-            return Genre.SIMULATION.value  
-            
-        # recategorize education games
-        if 'Education' in genres or 'Quiz' in genres:
-            if 'Adventure' in genres or 'Visual Novel' in genres:
-                return Genre.ADVENTURE_VISUAL.value
-            return Genre.MISC.value
         
-        # debatable, affects only a few games but usually the FPS aspect is more prominent than the rest
-        if 'First Person Shooter' in genres:
-            return Genre.FPS.value
-
-        # RPG takes precedence over adventure and others for ~60 games
-        if 'RPG' in genres or 'Role-Playing' in genres:
-            return Genre.RPG.value
-        
-        # puzzle takes precedence for ~50 games e.g. lrunn2, jetpack, oddworld
-        if 'Puzzle' in genres:
-            return Genre.PUZZLE.value
-        
-        # from here on, ignore 'Action' or 'Arcade' if there are subgenres defined, 
-        # otherwise they always take precedence
-        if len(genres) > 1 and genres[0] == 'Action':
-            genres.pop(0)
-        if len(genres) > 1 and genres[0] == 'Arcade':
-            genres.pop(0)
-        
-        # returns the first genre found, alphabetically
-        for genre in genres:
-            output = GENRE_MAPPER.get(genre, Genre.UNKNOWN)
-            if output != Genre.UNKNOWN:
-                return output.value
-        
-        # fallback - there are probably no genres defined (or Exo added a new genre name)
-        return Genre.UNKNOWN.value
         

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -113,7 +113,6 @@ class MetadataHandler:
     def parseXmlMetadata(self):
         xmlPath = os.path.join(self.exoCollectionDir, 'xml', util.getCollectionMetadataID(self.collectionVersion) + '.xml')
         metadatas = dict()
-        print (xmlPath)
         if os.path.exists(xmlPath):
             parser = etree.XMLParser(encoding="utf-8")
             games = etree.parse(xmlPath, parser=parser).findall(".//Game")
@@ -132,7 +131,7 @@ class MetadataHandler:
                         genres = self.get(g, 'Genre').split(';') if self.get(g, 'Genre') is not None else []
                         manual = self.get(g, 'ManualPath')
                         manualpath = util.localOSPath(os.path.join(self.exoCollectionDir, manual)) if manual is not None else None
-                        frontPic = None #util.findPics(name, self.cache)
+                        frontPic = util.findPics(name, self.cache)
                         metadata = DosGame(dosname, metadataname, name, genres, publisher, developer, releasedate, frontPic,
                                            manualpath, desc)
                         metadatas[metadata.dosname.lower()] = metadata

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -219,9 +219,10 @@ class MetadataHandler:
             
         if 'Board / Party Game' in genres:
             return Genre.PUZZLE.value
-            
-        # separate RPGs of any type
+        
+        # RPG takes precedence over adventure
         if 'RPG' in genres or 'Role-Playing' in genres:
+            # but give precedence to these other tags
             if 'Shooter' in genres:
                 return Genre.SHMUP.value
             if 'Fighting' in genres:
@@ -229,51 +230,54 @@ class MetadataHandler:
             if 'Platform' in genres:
                 return Genre.PLATFORM.value
             return Genre.RPG.value
-        
-        # remove action/adventure if more tags are defined
-        if 'Adventure' in genres and 'Action' in genres:
-            if len(genres) == 2:
-                return Genre.ACTION_ADVENTURE.value
-            else:
-                if genres == ['Action', 'Adventure', 'Text-Based']:
-                    return Genre.ACTION_ADVENTURE.value
-                genres.pop(genres.index('Action'))
-                genres.pop(genres.index('Adventure'))
-        
-        # prevent categorization as 'adventure' as these usually aren't arcade
-        if 'Arcade' in genres and 'Adventure' in genres:
+
+        if genres == ['Action']:
             return Genre.ACTION_ADVENTURE.value
-        
+
         if genres == ['Action', 'Arcade']:
             return Genre.ACTION_ADVENTURE.value
         
-        # prioritize these categories over others from here on
+        if genres == ['Action', 'Adventure']:
+            return Genre.ACTION_ADVENTURE.value
+         
+        if genres == ['Action', 'Adventure', 'Text-Based']:
+            return Genre.ACTION_ADVENTURE.value
+        
+        if genres == ['Action', 'Adventure', 'Simulation']:
+            return Genre.ACTION_ADVENTURE.value
+        
+        if genres == ['Adventure', 'Simulation']:
+            return Genre.ADVENTURE_VISUAL.value
+        
+        # puzzle takes precedence for ~50 games e.g. lrunn2, jetpack, oddworld
         if 'Puzzle' in genres:
             return Genre.PUZZLE.value
-
-        if 'Shooter' in genres:
-            return Genre.SHMUP.value
         
+        # debarable - this makes platform/shooters come up as shmup (e.g. turrican, duken12)
+        if 'Shooter' in genres:
+           return Genre.SHMUP.value
+        
+        # platform takes precedence over fighting and adventure
         if 'Platform' in genres:
             return Genre.PLATFORM.value
         
+        # reclassify cotsword, sidewalk, batret, qeye, spidssix
         if 'Fighting' in genres:
             return Genre.BEATEMUP.value
         
-        # from here on, ignore 'Action' if there are subgenres defined
+        # from here on, ignore 'Action' or 'Arcade' if there are subgenres defined, 
+        # otherwise they always take precedence
         if len(genres) > 1 and genres[0] == 'Action':
             genres.pop(0)
-        
-        # same logic for Arcade
         if len(genres) > 1 and genres[0] == 'Arcade':
             genres.pop(0)
-                
-        # if not in special cases, return the first mapped genre found
+        
+        # returns the first genre found, alphabetically
         for genre in genres:
             output = GENRE_MAPPER.get(genre, Genre.UNKNOWN)
             if output != Genre.UNKNOWN:
                 return output.value
         
-        # fallback - probably no genres defined
+        # fallback - there are probably no genres defined (or Exo added a new genre name)
         return Genre.UNKNOWN.value
         

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -1,5 +1,4 @@
 import collections
-from enum import Enum
 import os
 import platform
 import util
@@ -8,93 +7,10 @@ import sys
 import xml.etree.ElementTree as etree
 from xml.dom import minidom
 
+from genre_mapping import Genre, GENRE_MAPPER, MULTI_GENRE_MAPPER
+
 DosGame = collections.namedtuple('DosGame',
                                  'dosname metadataname name genres publisher developer year frontPic manual desc')
-
-
-class Genre(Enum):
-    # the target genres we want to map to
-    UNKNOWN             = "Unknown"
-    MISC                = "Misc"
-    ACTION_ADVENTURE    = "Action-Adventure"
-    ADVENTURE_VISUAL    = "Adventure-Visual"
-    BEATEMUP            = "BeatEmUp"
-    FPS                 = "Gun-FPS"
-    PINBALL             = "Pinball"
-    PLATFORM            = "Platform"
-    PUZZLE              = "Puzzle"
-    RACING              = "Racing"
-    RPG                 = "RPG"
-    SIMULATION          = "Simulation"
-    SHMUP               = "ShootEmUp"
-    SPORTS              = "Sport"
-    STRATEGY_MANAGEMENT = "Strategy-Management"
-    TOOLS               = "Tools"
-
-# defines direct mappings (i.e. if match, return the value)
-GENRE_MAPPER = {
-    'Action':               Genre.ACTION_ADVENTURE,
-    'Adventure':            Genre.ADVENTURE_VISUAL,
-    'App':                  Genre.TOOLS,
-    'Arcade':               Genre.MISC,
-    'Beat \'em Up':         Genre.BEATEMUP,
-    'Board / Party Game':   Genre.PUZZLE,
-    'Board':                Genre.PUZZLE,
-    'Cards / Tiles':        Genre.PUZZLE,
-    'Casino':               Genre.PUZZLE,
-    'Construction and Management Simulation': Genre.STRATEGY_MANAGEMENT,
-    'Creativity':           Genre.TOOLS,
-    'Driving':              Genre.RACING,
-    'FPS':                  Genre.FPS,
-    'Fighting':             Genre.BEATEMUP,
-    'First Person Shooter': Genre.FPS,
-    'Flight Simulator':     Genre.SIMULATION,
-    'Game Show':            Genre.PUZZLE,
-    'Interactive Fiction':  Genre.ADVENTURE_VISUAL,
-    'Interactive Movie':     Genre.ADVENTURE_VISUAL,
-    'Life Simulation':      Genre.MISC,
-    'Managerial':           Genre.STRATEGY_MANAGEMENT,
-    'Pinball':              Genre.PINBALL,
-    'Platform':             Genre.PLATFORM,
-    'Puzzle':               Genre.PUZZLE,
-    'RPG':                  Genre.RPG,
-    'Racing / Driving':     Genre.RACING,
-    'Racing':               Genre.RACING,
-    'Reference':            Genre.TOOLS,    
-    'Role-Playing':         Genre.RPG,
-    'Paddle / Pong':        Genre.ACTION_ADVENTURE,
-    'Shooter':              Genre.SHMUP,
-    'Simulation':           Genre.SIMULATION,
-    'Sports':               Genre.SPORTS,
-    'Strategy':             Genre.STRATEGY_MANAGEMENT,
-    'Text-Based':           Genre.ADVENTURE_VISUAL,
-    'Vehicle Simulation':   Genre.SIMULATION,
-    'Visual Novel':         Genre.ADVENTURE_VISUAL,
-}    
-
-# as above, but applies for combined genres (used for overides)
-MULTI_GENRE_MAPPER = {
-    "['Action', 'Arcade']":                   Genre.ACTION_ADVENTURE,
-    "['Action', 'Adventure']":                Genre.ACTION_ADVENTURE,
-    "['Action', 'Adventure', 'Fighting']":    Genre.BEATEMUP,
-    "['Action', 'Adventure', 'Platform']":    Genre.PLATFORM,
-    "['Action', 'Adventure', 'Text-Based']":  Genre.ACTION_ADVENTURE,
-    "['Action', 'Adventure', 'Simulation']":  Genre.ACTION_ADVENTURE,
-    "['Action', 'Fighting', 'Role-Playing']": Genre.BEATEMUP,
-    "['Action', 'Platform', 'Role-Playing']": Genre.PLATFORM,
-    "['Action', 'Adventure', 'Shooter']":     Genre.SHMUP,
-    "['Action', 'Adventure', 'Platform', 'Puzzle']": Genre.PUZZLE,
-    "['Action', 'Fighting', 'Shooter']":      Genre.SHMUP,
-    "['Action', 'Fighting', 'Platform']":     Genre.PLATFORM,
-    "['Action', 'Platform', 'Shooter']":      Genre.SHMUP,
-    "['Action', 'Role-Playing', 'Shooter']":  Genre.SHMUP,
-    "['Action', 'Adventure', 'Platform', 'Shooter']": Genre.SHMUP,
-    "['Adventure', 'Fighting']":              Genre.BEATEMUP,
-    "['Adventure', 'Platform']":              Genre.PLATFORM,
-    "['Adventure', 'Simulation']":            Genre.ADVENTURE_VISUAL,
-    "['Board / Party Game', 'Role-Playing', 'Strategy']": Genre.PUZZLE,
-    "['Platform', 'Shooter']":                Genre.SHMUP, 
-}
 
 # Metadata exporting
 class MetadataHandler:

--- a/test/test_genres.py
+++ b/test/test_genres.py
@@ -2,7 +2,8 @@
 
 import pandas as pd
 from logger import Logger
-from metadatahandler import MetadataHandler, GENRE_MAPPER
+from metadatahandler import MetadataHandler
+from genre_mapping import GENRE_MAPPER
 from util import buildCache
 from tabulate import tabulate
 

--- a/test/test_genres.py
+++ b/test/test_genres.py
@@ -1,0 +1,30 @@
+# Tester file for genre metadata mapping
+
+import pandas as pd
+from logger import Logger
+from metadatahandler import MetadataHandler, GENRE_MAPPER
+from tabulate import tabulate
+
+logger = Logger()
+
+exo_folder = r'Z:\\'
+
+mdh = MetadataHandler(exo_folder, 'eXoDOS v5', False, logger)
+data = mdh.parseXmlMetadata()
+
+result = []
+for name in data:
+    game = data[name]
+    oldGenre = '' # mdh.buildGenre_old(game) <-- uncomment and place old function to run side by side
+    newGenre = mdh.buildGenre(game)
+    genres = sorted([g.strip() for g in list(set(game.genres))])
+    if oldGenre != newGenre:
+        if 'Interactive Movie' in genres:
+            continue
+        if oldGenre not in ['Sports', 'Strategy-Gestion', 'Race']:
+            result.append( (name, str(genres), oldGenre, newGenre) )
+
+df = pd.DataFrame(result, columns=['name', 'exo', 'old', 'new'])
+df.to_csv(r'.\game_genres_compare.csv')
+
+print(tabulate(df, tablefmt='psql'))

--- a/test/test_genres.py
+++ b/test/test_genres.py
@@ -3,19 +3,84 @@
 import pandas as pd
 from logger import Logger
 from metadatahandler import MetadataHandler, GENRE_MAPPER
+from util import buildCache
 from tabulate import tabulate
 
 logger = Logger()
 
 exo_folder = r'Z:\\'
+collection = 'eXoDOS v5'
 
-mdh = MetadataHandler(exo_folder, 'eXoDOS v5', False, logger)
+def buildGenre_old(dosGame):
+    if dosGame is not None and dosGame.genres is not None:
+        if 'Flight Simulator' in dosGame.genres or 'Vehicle Simulation' in dosGame.genres:
+            return 'Simulation'
+        elif "Education" in dosGame.genres or "Quiz" in dosGame.genres:
+            if "Adventure" in dosGame.genres or "Visual Novel" in dosGame.genres:
+                return "Adventure-Visual"
+            else:
+                return 'Misc'
+        elif "Racing" in dosGame.genres or "Driving" in dosGame.genres or "Racing / Driving" in dosGame.genres:
+            return "Race"
+        elif 'Sports' in dosGame.genres:
+            return 'Sports'
+        elif 'Pinball' in dosGame.genres:
+            return 'Pinball'
+        elif "Puzzle" in dosGame.genres or "Board" in dosGame.genres or "Board / Party Game" in dosGame.genres \
+                or "Casino" in dosGame.genres or 'Cards / Tiles' in dosGame.genres or 'Game Show' in dosGame.genres:
+            return "Puzzle"
+        elif 'Shooter' in dosGame.genres:
+            return 'ShootEmUp'
+        elif 'Platform' in dosGame.genres:
+            return 'Platform'
+        elif 'FPS' in dosGame.genres or 'First Person Shooter' in dosGame.genres:
+            return 'Gun-FPS'
+        elif 'Fighting' in dosGame.genres or 'Beat \'em Up' in dosGame.genres:
+            return 'BeatEmUp'
+        elif 'Strategy' in dosGame.genres and "Puzzle" not in dosGame.genres:
+            return 'Strategy-Gestion'
+        elif 'RPG' in dosGame.genres or 'Role-Playing' in dosGame.genres:
+            return 'RPG'
+        elif 'Interactive Fiction' in dosGame.genres:
+            return "Adventure-Visual"
+        elif "Adventure" in dosGame.genres and "Action" in dosGame.genres:
+            return "Action-Adventure"
+        elif "Adventure" in dosGame.genres or "Visual Novel" in dosGame.genres:
+            return "Adventure-Visual"
+        elif 'Simulation' in dosGame.genres and 'Managerial' in dosGame.genres:
+            return 'Strategy-Gestion'
+        elif 'Construction and Management Simulation' in dosGame.genres:
+            return 'Strategy-Gestion'
+        elif 'Simulation' in dosGame.genres:
+            return 'Simulation'
+        elif 'Shooter' in dosGame.genres:
+            return 'ShootEmUp'
+        elif 'Action' in dosGame.genres:
+            return 'Action-Adventure'
+        elif 'Arcade' in dosGame.genres or 'Life Simulation' in dosGame.genres:
+            return 'Misc'
+        elif 'Creativity' in dosGame.genres or 'App' in dosGame.genres or 'Reference' in dosGame.genres:
+            return 'Tools'
+        else:
+            return 'Unknown'
+    else:
+        return 'Unknown'
+            
+
+# takes a while in the first run. 
+# can be skipped by commenting out the use of self.cache in parseXmlMetadata
+cache = buildCache('.\\', exo_folder, collection, logger)
+
+mdh = MetadataHandler(exo_folder, collection, cache, logger)
 data = mdh.parseXmlMetadata()
+
+if len(data) == 0:
+    raise ValueError("Unable to load metadata, exiting")
 
 result = []
 for name in data:
     game = data[name]
-    oldGenre = '' # mdh.buildGenre_old(game) <-- uncomment and place old function to run side by side
+    oldGenre = buildGenre_old(game)
     newGenre = mdh.buildGenre(game)
     genres = sorted([g.strip() for g in list(set(game.genres))])
     if oldGenre != newGenre:
@@ -28,3 +93,6 @@ df = pd.DataFrame(result, columns=['name', 'exo', 'old', 'new'])
 df.to_csv(r'.\game_genres_compare.csv')
 
 print(tabulate(df, tablefmt='psql'))
+
+
+


### PR DESCRIPTION
## Changes
+ enhanced mapping logic to use lookup table with only a few exceptions
+ fixed some English names for categories

## Test code
<pre>

class MockDosGame:
    def __init__(self, value):
        self.genres = [value]

mdh = MetadataHandler(r'c:\temp\\', 2, False, False)
print("hello")
for key in GAME_MAPPER.keys():
    oldValue = mdh.buildGenre_old(MockDosGame(key))
    newValue = mdh.buildGenre(MockDosGame(key))
    if oldValue != newValue:
        print ("[%s]\n    diff: '%s' vs. '%s'" % (key, oldValue, newValue))
            
</pre>

### Results 
<pre>

# Fixed: "Gestion" is French

[Strategy]
    diff: 'Strategy-Gestion' vs. 'Strategy-Management'
[Construction and Management Simulation]
    diff: 'Strategy-Gestion' vs. 'Strategy-Management'

# Fixed:  in English, 'Racing' is more often used than 'Race' (like Course in French)

[Driving]
    diff: 'Race' vs. 'Racing'
[Racing / Driving]
    diff: 'Race' vs. 'Racing'
[Racing]
    diff: 'Race' vs. 'Racing'

# Fixed: 'IF' is usually text adventures (not sure if mapping was intentional)

[Interactive Fiction]
    diff: 'Adventure-Visual' vs. 'Adventure-Text'

# Fixed: found an unhandled case
[Managerial]
    diff: 'Unknown' vs. 'Strategy-Management'

</pre>