### PR TITLE
Added ability for long Folder names in batocera/retrobat

### DIFF
--- a/commandhandler.py
+++ b/commandhandler.py
@@ -240,7 +240,7 @@ class CommandHandler:
         # Mount command needs to be absolute linux path
         if prString.strip().startswith('.'):
             prString = prString.strip()[1:]
-        gameString = "/" + self.gGator.genre + "/" + self.gGator.game + ".pc" if self.gGator.useGenreSubFolders else "/" + self.gGator.game + ".pc"
+        gameString = "/" + self.gGator.genre + "/" + self.gGator.gameDir if self.gGator.useGenreSubFolders else "/" + self.gGator.gameDir
         prString = util.getRomsFolderPrefix(self.gGator.conversionType,
                                             self.gGator.conversionConf) + gameString + prString.strip()
         prString = ' "' + prString.replace("\\", "/") + '"'

--- a/conf/conf-exo.conf
+++ b/conf/conf-exo.conf
@@ -16,6 +16,9 @@ mapper = Yes
 useKeyb2Joypad = 1
 # Map controler analog sticks
 mapSticks = 0
+# Allow long Folder Names ["Long Game Name (YEAR).pc" not "LongGame.pc"] (Batocera Only)
+# Will not Rename Existing Folders!
+longGameFolder = 0
 # Activate direct download on demand (only for eXoDOS)
 downloadOnDemand = 1
 # Pre-Extract Games (MiSTeR and DOS Native only)

--- a/exoconverter.py
+++ b/exoconverter.py
@@ -111,7 +111,9 @@ class ExoConverter:
                                self.conversionType, self.conversionConf, self.exoCollectionDir, self.fullnameToGameDir,
                                self.scriptDir, self.keyb2joypad, self.logger)
 
-        if not os.path.exists(gGator.getLocalGameOutputDir()):
+        # for batocera(maybe others) this will allow re-naming etc of the folders if already existing
+        # for everything else it works just as well as it did previously(basically won't convert from one export type to another)
+        if not util.moveFolderifExist(self.useGenreSubFolders, metadata, genre, game, gameDir, self.outputDir, self.logger):
             self.__copyGameDataToOutputDir__(gGator)
             gGator.convertGame()
         else:

--- a/exoconverter.py
+++ b/exoconverter.py
@@ -13,7 +13,7 @@ from gamegenerator import GameGenerator
 # Main Converter
 class ExoConverter:
 
-    def __init__(self, games, cache, scriptDir, collectionVersion, collectionDir, outputDir, conversionType,
+    def __init__(self, games, cache, scriptDir, collectionVersion, collectionDir, outputDir, conversionType, useLongFolderNames, 
                  useGenreSubFolders, conversionConf, fullnameToGameDir, postProcess, logger):
         self.games = games
         self.cache = cache
@@ -26,6 +26,7 @@ class ExoConverter:
         self.collectionGamesConfDir = util.getCollectionGamesConfDir(collectionDir, collectionVersion)
         self.outputDir = outputDir
         self.conversionType = conversionType
+        self.useLongFolderNames = useLongFolderNames
         self.useGenreSubFolders = useGenreSubFolders
         self.conversionConf = conversionConf
         self.metadataHandler = MetadataHandler(collectionDir, collectionVersion, self.cache, self.logger)
@@ -99,10 +100,14 @@ class ExoConverter:
     def __convertGame__(self, game, gamelist, totalSize, count):
         genre = self.metadataHandler.buildGenre(self.metadataHandler.metadatas.get(game.lower()))
         self.logger.log(">>> %i/%i >>> %s: starting conversion" % (count, totalSize, game))
-        metadata = self.metadataHandler.processGame(game, gamelist, genre, self.outputDir, self.useGenreSubFolders,
+        metadata = self.metadataHandler.processGame(game, gamelist, genre, self.outputDir, self.useLongFolderNames, self.useGenreSubFolders,
                                                     self.conversionType)
 
-        gGator = GameGenerator(game, genre, self.outputDir, self.collectionVersion, self.useGenreSubFolders, metadata,
+        if self.conversionType == util.batocera and self.useLongFolderNames:
+            gameDir = util.getCleanGameID(metadata,'.pc')
+        else:
+            gameDir = game + ".pc"
+        gGator = GameGenerator(game, gameDir, genre, self.outputDir, self.collectionVersion, self.useLongFolderNames, self.useGenreSubFolders, metadata,
                                self.conversionType, self.conversionConf, self.exoCollectionDir, self.fullnameToGameDir,
                                self.scriptDir, self.keyb2joypad, self.logger)
 

--- a/exoconverter.py
+++ b/exoconverter.py
@@ -103,7 +103,7 @@ class ExoConverter:
         metadata = self.metadataHandler.processGame(game, gamelist, genre, self.outputDir, self.useLongFolderNames, self.useGenreSubFolders,
                                                     self.conversionType)
 
-        if self.conversionType == util.batocera and self.useLongFolderNames:
+        if (self.conversionType == util.batocera or self.conversionType == util.retrobat) and self.useLongFolderNames:
             gameDir = util.getCleanGameID(metadata,'.pc')
         else:
             gameDir = game + ".pc"
@@ -111,9 +111,7 @@ class ExoConverter:
                                self.conversionType, self.conversionConf, self.exoCollectionDir, self.fullnameToGameDir,
                                self.scriptDir, self.keyb2joypad, self.logger)
 
-        # for batocera(maybe others) this will allow re-naming etc of the folders if already existing
-        # for everything else it works just as well as it did previously(basically won't convert from one export type to another)
-        if not util.moveFolderifExist(self.useGenreSubFolders, metadata, genre, game, gameDir, self.outputDir, self.logger):
+        if not os.path.exists(gGator.getLocalGameOutputDir()):
             self.__copyGameDataToOutputDir__(gGator)
             gGator.convertGame()
         else:

--- a/exoconverter.py
+++ b/exoconverter.py
@@ -117,6 +117,7 @@ class ExoConverter:
         else:
             self.logger.log("  already converted in output folder")
 
+        util.checkMultipleofSameGame(self.useGenreSubFolders, metadata, genre, game, gameDir, self.outputDir, self.logger)
         self.logger.log("")
 
     # Copy game data from collection to output dir

--- a/exogui.py
+++ b/exogui.py
@@ -57,6 +57,7 @@ class ExoGUI:
         self.conversionTypeComboBox = None
         self.conversionTypeValues = None
         self.downloadOnDemandCheckButton = None
+        self.longGameFolderCheckButton = None
         self.mapperLabel = None
         self.mapperComboBox = None
         self.mapperValues = None
@@ -235,6 +236,15 @@ class ExoGUI:
                                                           offvalue=0)
         wckToolTips.register(self.downloadOnDemandCheckButton, self.guiStrings['downloadOnDemand'].help)
         self.downloadOnDemandCheckButton.grid(column=3, row=0, sticky="E", pady=5)
+
+        self.guiVars['longGameFolder'] = Tk.IntVar()
+        self.guiVars['longGameFolder'].set(self.configuration['longGameFolder'])
+        self.longGameFolderCheckButton = Tk.Checkbutton(self.collectionFrame,
+                                                          text=self.guiStrings['longGameFolder'].label,
+                                                          variable=self.guiVars['longGameFolder'], onvalue=1,
+                                                          offvalue=0)
+        wckToolTips.register(self.longGameFolderCheckButton, self.guiStrings['longGameFolder'].help)
+        self.longGameFolderCheckButton.grid(column=4, row=0, sticky="", pady=5)
 
         self.guiVars['preExtractGames'] = Tk.IntVar()
         self.guiVars['preExtractGames'].set(self.configuration['preExtractGames'])
@@ -668,7 +678,7 @@ class ExoGUI:
                               'filter', 'selectall', 'unselectall', 'loadCustom', 'saveCustom', 'selectOutputDir',
                               'selectCollectionDir', 'selectSelectionPath']:
                 if key.help:
-                    confFile.write('# ' + key.help.replace('#n', '\n# ') + '\n')
+                    confFile.write('# ' + key.help.replace('\n', '\n# ') + '\n')
                 if key.id == 'images':
                     imagesValue = self.guiVars[self.guiStrings['images'].label + ' #1'].get()
                     if self.guiStrings['images'].label + ' #2' in self.guiVars:
@@ -719,6 +729,7 @@ class ExoGUI:
         self.logger.log('\n<--------- Starting ' + self.setKey + ' Process --------->')
         collectionDir = self.guiVars['collectionDir'].get()
         conversionType = self.guiVars['conversionType'].get()
+        useLongFolderNames = True if self.guiVars['longGameFolder'].get() == 1 else False
         useGenreSubFolders = True if self.guiVars['genreSubFolders'].get() == 1 else False
         outputDir = self.guiVars['outputDir'].get()
         # Configuration parameters
@@ -751,7 +762,7 @@ class ExoGUI:
             self.logger.log("%s doesn't seem to be a valid collection folder" % collectionDir)
         else:
             exoConverter = ExoConverter(games, self.cache, self.scriptDir, collectionVersion, collectionDir, outputDir,
-                                        conversionType, useGenreSubFolders, conversionConf, self.fullnameToGameDir,
+                                        conversionType, useLongFolderNames, useGenreSubFolders, conversionConf, self.fullnameToGameDir,
                                         partial(self.postProcess), self.logger)
             _thread.start_new(exoConverter.convertGames, ())
 
@@ -778,7 +789,7 @@ class ExoGUI:
                            self.expertModeCheckButton,
                            self.loadCustomButton, self.saveCustomButton, self.selectionPathEntry,
                            self.selectSelectionPathButton,
-                           self.preExtractGamesCheckButton, self.downloadOnDemandCheckButton]
+                           self.preExtractGamesCheckButton, self.downloadOnDemandCheckButton, self.longGameFolderCheckButton]
 
         if clickedProcess or collectionVersion == 'None':
             [self.__setComponentState__(c, 'disabled' if clickedProcess else 'normal') for c in entryComponents]
@@ -789,6 +800,8 @@ class ExoGUI:
             [self.__setComponentState__(c, 'normal') for c in mainButtons + otherComponents + entryComponents]
             self.__setComponentState__(self.preExtractGamesCheckButton,
                                        'normal' if self.guiVars['conversionType'].get() == util.mister else 'disabled')
+            self.__setComponentState__(self.longGameFolderCheckButton,
+                                       'normal' if self.guiVars['conversionType'].get() == util.batocera else 'disabled')
 
     def postProcess(self):
         self.__unselectAll__()

--- a/exogui.py
+++ b/exogui.py
@@ -801,7 +801,7 @@ class ExoGUI:
             self.__setComponentState__(self.preExtractGamesCheckButton,
                                        'normal' if self.guiVars['conversionType'].get() == util.mister else 'disabled')
             self.__setComponentState__(self.longGameFolderCheckButton,
-                                       'normal' if self.guiVars['conversionType'].get() == util.batocera else 'disabled')
+                                       'normal' if self.guiVars['conversionType'].get() == util.batocera or self.guiVars['conversionType'].get() == util.retrobat else 'disabled')
 
     def postProcess(self):
         self.__unselectAll__()

--- a/gamegenerator.py
+++ b/gamegenerator.py
@@ -11,12 +11,14 @@ from mapping import Mapping
 # contains all data and conf about generating a given game
 class GameGenerator:
 
-    def __init__(self, game, genre, outputDir, collectionVersion, useGenreSubFolders, metadata, conversionType,
+    def __init__(self, game, gameDir, genre, outputDir, collectionVersion, useLongFolderNames, useGenreSubFolders, metadata, conversionType,
                  conversionConf, exoCollectionDir, fullnameToGameDir, scriptDir, keyb2joypad, logger):
         self.game = game
+        self.gameDir = gameDir
         self.collectionVersion = collectionVersion
         self.genre = genre
         self.outputDir = outputDir
+        self.useLongFolderNames = useLongFolderNames
         self.useGenreSubFolders = useGenreSubFolders
         self.metadata = metadata
         self.conversionType = conversionType
@@ -40,7 +42,7 @@ class GameGenerator:
 
     # returns local game ouput dir of the generated game
     def getLocalGameOutputDir(self):
-        return os.path.join(self.getLocalParentOutputDir(), self.game + ".pc")
+        return os.path.join(self.getLocalParentOutputDir(), self.gameDir)
 
     # returns local game data output dir of the generated game
     def getLocalGameDataOutputDir(self):
@@ -135,8 +137,8 @@ class GameGenerator:
         shutil.move(os.path.join(self.getLocalGameOutputDir()), emuElecDataDir)
         os.rename(os.path.join(emuElecDataDir, self.game + '.pc'), os.path.join(emuElecDataDir, self.game))
         # move *.bat *.map and *.cfg to pc/*.pc folder and rename *.cfg to dosbox-SDL2.conf
-        emuelecConfOutputDir = os.path.join(self.outputDir, 'pc', self.genre, self.game + ".pc") \
-            if self.useGenreSubFolders else os.path.join(self.outputDir, 'pc', self.game + ".pc")
+        emuelecConfOutputDir = os.path.join(self.outputDir, 'pc', self.genre, self.gameDir) \
+            if self.useGenreSubFolders else os.path.join(self.outputDir, 'pc', self.gameDir)
         if not os.path.exists(emuelecConfOutputDir):
             os.makedirs(emuelecConfOutputDir)
         open(os.path.join(emuelecConfOutputDir, util.getCleanGameID(self.metadata, '.bat')),'w').close()
@@ -300,7 +302,7 @@ class GameGenerator:
         dosboxCfg = open(os.path.join(self.getLocalGameOutputDir(), "dosbox.cfg"), 'a')
         # add mount c at end of dosbox.cfg
         romsFolder = util.getRomsFolderPrefix(self.conversionType, self.conversionConf)
-        retropieGameDir = romsFolder + "/" + self.genre + "/" + self.game + ".pc" if self.useGenreSubFolders else romsFolder + "/" + self.game + ".pc"
+        retropieGameDir = romsFolder + "/" + self.genre + "/" + self.gameDir if self.useGenreSubFolders else romsFolder + "/" + self.gameDir
         dosboxCfg.write("mount c " + retropieGameDir + "\n")
         dosboxCfg.write("c:\n")
         # copy all instructions from dosbox.bat to end of dosbox.cfg

--- a/gui/gui-en-exo.csv
+++ b/gui/gui-en-exo.csv
@@ -13,6 +13,7 @@ genreSubFolders;Use genre subfolders;Check to use genre subfolders for converted
 mapper;Mapper;Use controls mapping
 useKeyb2Joypad;Use Keyb2Joypad;Use keyb2joypad mappings
 mapSticks; Map Analog Sticks;Map controler analog sticks
+longGameFolder;Long Folder Names;Allow long Folder Names ["Long Game Name (YEAR).pc" not "LongGame.pc"] (Batocera Only)#nWill not Rename Existing Folders!
 downloadOnDemand;Download on demand;Activate direct download on demand (only for eXoDOS)
 preExtractGames;Pre-extract Games;Pre-Extract Games (MiSTeR and DOS Native only)
 debugMode;Debug Mode; in debug mode, pause instruction will be added and [autoexec] part left commented in dosbox.cfg

--- a/gui/gui-en-exo.csv
+++ b/gui/gui-en-exo.csv
@@ -13,7 +13,7 @@ genreSubFolders;Use genre subfolders;Check to use genre subfolders for converted
 mapper;Mapper;Use controls mapping
 useKeyb2Joypad;Use Keyb2Joypad;Use keyb2joypad mappings
 mapSticks; Map Analog Sticks;Map controler analog sticks
-longGameFolder;Long Folder Names;Allow long Folder Names ["Long Game Name (YEAR).pc" not "LongGame.pc"] (Batocera Only)#nWill not Rename Existing Folders!
+longGameFolder;Long Folder Names;Allow long Folder Names ["Long Game Name (YEAR).pc" not "LongGame.pc"] (Batocera/RetroBat Only)#nWill not Rename Existing Folders!
 downloadOnDemand;Download on demand;Activate direct download on demand (only for eXoDOS)
 preExtractGames;Pre-extract Games;Pre-Extract Games (MiSTeR and DOS Native only)
 debugMode;Debug Mode; in debug mode, pause instruction will be added and [autoexec] part left commented in dosbox.cfg

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -130,9 +130,7 @@ class MetadataHandler:
                 game) + ".pc" if useGenreSubFolders else "./" + self.__cleanXmlString__(game) + ".pc"
 
         existsInGamelist = [child for child in root.iter('game') if
-                            #self.__getNode__(child, "name") == dosGame.name and self.__getNode__(child, "releasedate") == year]
-                            #better to have two entries than a wrong entry.
-                            self.__getNode__(child, "path") == path and self.__getNode__(child, "releasedate") == year]
+                            self.__getNode__(child, "name") == dosGame.name and self.__getNode__(child, "releasedate") == year]
         if len(existsInGamelist) == 0:
             gameElt = etree.SubElement(root, 'game')
             etree.SubElement(gameElt, 'path').text = path
@@ -144,6 +142,10 @@ class MetadataHandler:
             etree.SubElement(gameElt, 'genre').text = genre
             etree.SubElement(gameElt, 'manual').text = manual
             etree.SubElement(gameElt, 'image').text = frontPic
+        else:
+            #game exists lets make sure path is correct to whats been done with subFolders/longNames
+            for child in existsInGamelist:
+                child.find("path").text = path
 
     # Convert multi genres exo collection format to a single one
     @staticmethod

--- a/metadatahandler.py
+++ b/metadatahandler.py
@@ -122,7 +122,7 @@ class MetadataHandler:
         if conversionType == util.retropie:
             path = "./" + genre + "/" + util.getCleanGameID(dosGame,'.conf') if useGenreSubFolders \
                 else "./" + util.getCleanGameID(dosGame, '.conf')
-        elif conversionType == util.batocera and useLongFolderNames:
+        elif (conversionType == util.batocera or conversionType == util.retrobat) and useLongFolderNames:
             path = "./" + genre + "/" + util.getCleanGameID(dosGame,'.pc') if useGenreSubFolders \
                 else "./" + util.getCleanGameID(dosGame, '.pc')
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2021.10.8
+chardet==4.0.0
+charset-normalizer==2.0.12
+idna==3.3
+Pillow==9.0.1
+requests==2.27.1
+tk==0.1.0
+urllib3==1.26.8

--- a/util.py
+++ b/util.py
@@ -1,6 +1,7 @@
 import os.path
 import platform
 import collections
+import shutil
 from PIL import Image
 import requests
 import urllib.request
@@ -298,3 +299,40 @@ def buildCache(scriptDir, collectionDir, collection, logger):
     logger.log("gameplayPicCache: %i entities" % len(gameplayPicCache.keys()))
 
     return frontPicCache, titlePicCache, gameplayPicCache
+
+def moveFolderifExist(useGenreSubFolders, metadata, genre, game, gameDir, outputDir, logger):
+    wantedPath = os.path.join(outputDir, genre, gameDir) if useGenreSubFolders else os.path.join(outputDir,gameDir)
+    paths = {
+    'shortPath':        os.path.join(outputDir,game + ".pc"),
+    'longPath':         os.path.join(outputDir,getCleanGameID(metadata,".pc")),
+    'shortPathGenre':   os.path.join(outputDir,genre,game + ".pc"),
+    'longPathGenre':    os.path.join(outputDir,genre,getCleanGameID(metadata,".pc"))
+    }
+
+    totalExistingPaths = 0
+    existingPath = []
+    for name,path in paths.items():
+        if os.path.exists(path):
+            existingPath.append(path)
+            totalExistingPaths += 1
+            logger.log("  Existing Path: " + path)
+
+    if totalExistingPaths > 1:
+        logger.log("    There can only be one, aborting auto rename.")
+        logger.log("    If no Errors, gamelist.xml will be accurate.")
+        for path in existingPath:
+            if path == wantedPath:
+                return True
+        #more than 1 path already, don't know what they want so create requested folder(will result in duplicates/triplicates/quad)
+        return False
+    elif totalExistingPaths == 0:
+        #game folder is non existent in any path, so create it.
+        return False
+    
+    #only one existing path found rename it to wanted path
+    if wantedPath != existingPath[0]:
+        logger.log("  Moving Existing -> " + wantedPath)
+        shutil.move(existingPath[0],wantedPath)
+        #moved it so now its exists
+        return True
+    return True

--- a/util.py
+++ b/util.py
@@ -310,10 +310,8 @@ def checkMultipleofSameGame(useGenreSubFolders, metadata, genre, game, gameDir, 
     }
 
     totalExistingPaths = 0
-    existingPath = []
     for name,path in paths.items():
         if os.path.exists(path):
-            existingPath.append(path)
             totalExistingPaths += 1
             logger.log("  Existing Path: " + path)
 

--- a/util.py
+++ b/util.py
@@ -116,7 +116,7 @@ def loadUIStrings(scriptDir, guiStringsFile):
     for line in file.readlines()[1:]:
         confLine = line.split(";")
         if len(confLine) == 3:
-            guiStrings[confLine[0]] = GUIString(confLine[0], confLine[1], confLine[2].rstrip('\n\r '), order)
+            guiStrings[confLine[0]] = GUIString(confLine[0], confLine[1], confLine[2].rstrip('\n\r ').replace("#n","\n"), order)
             order = order + 1
     file.close()
     return guiStrings

--- a/util.py
+++ b/util.py
@@ -300,6 +300,26 @@ def buildCache(scriptDir, collectionDir, collection, logger):
 
     return frontPicCache, titlePicCache, gameplayPicCache
 
+def checkMultipleofSameGame(useGenreSubFolders, metadata, genre, game, gameDir, outputDir, logger):
+    wantedPath = os.path.join(outputDir, genre, gameDir) if useGenreSubFolders else os.path.join(outputDir,gameDir)
+    paths = {
+    'shortPath':        os.path.join(outputDir,game + ".pc"),
+    'longPath':         os.path.join(outputDir,getCleanGameID(metadata,".pc")),
+    'shortPathGenre':   os.path.join(outputDir,genre,game + ".pc"),
+    'longPathGenre':    os.path.join(outputDir,genre,getCleanGameID(metadata,".pc"))
+    }
+
+    totalExistingPaths = 0
+    existingPath = []
+    for name,path in paths.items():
+        if os.path.exists(path):
+            existingPath.append(path)
+            totalExistingPaths += 1
+            logger.log("  Existing Path: " + path)
+
+    if totalExistingPaths > 1:
+        logger.log("  \tDue to not Clearing output folder you have...\n\t\t\t\t MULTIPLE COPIES.\n\t\tIf changing conversion type this may lead to bigger issues.")
+
 def moveFolderifExist(useGenreSubFolders, metadata, genre, game, gameDir, outputDir, logger):
     wantedPath = os.path.join(outputDir, genre, gameDir) if useGenreSubFolders else os.path.join(outputDir,gameDir)
     paths = {


### PR DESCRIPTION
#99 
not sure what else this would work in, made sure it works as well as previous code base for existing things but for batocera it will allow long Folder names so they can be scraped easily

Tested extensively with Mario Teaches Typing and C&C Red Alert

Also made it so that it will rename an already existing folder if it exists so Genre/game.pc would be renamed to game.pc if you removed the genre checkbox

and finally it will update the path in Gamelist.xml rather than creating duplicates.